### PR TITLE
#1 Fixing dagbag_import_timeout empty value issue

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,7 +56,7 @@ airflow_max_active_runs_per_dag: 16
 airflow_fernet_key:
 
 airflow_donot_pickle: False
-airflow_dagbag_import_timeout:
+airflow_dagbag_import_timeout: 30
 
 airflow_task_runner: BashTaskRunner
 


### PR DESCRIPTION
Setting default value of airflow_dagbag_import_timeout to 30 seconds (default value with a regular Airflow installation).