### PR TITLE
#8 Conditioned adding of superuser_filter and data_profiler_filter in airflow.cfg.j2

### DIFF
--- a/templates/airflow.cfg.j2
+++ b/templates/airflow.cfg.j2
@@ -362,8 +362,12 @@ uri = {{ airflow_ldap_uri }}
 user_filter = {{ airflow_ldap_user_filter }}
 # in case of Active Directory you would use: user_name_attr = sAMAccountName
 user_name_attr = {{ airflow_ldap_user_name_attr }}
+{% if airflow_ldap_superuser_filter %}
 superuser_filter = {{ airflow_ldap_superuser_filter }}
+{% endif %}
+{% if airflow_ldap_data_profiler_filter %}
 data_profiler_filter = {{ airflow_ldap_data_profiler_filter }}
+{% endif %}
 bind_user = {{ airflow_ldap_bind_user }}
 bind_password = {{ airflow_ldap_bind_password }}
 basedn = {{ airflow_ldap_basedn }}


### PR DESCRIPTION
Both variables are added just if `airflow_ldap_superuser_filter` or `airflow_ldap_data_profiler_filter` exist, respectively