### PR TITLE
Use less resources and use import_tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ These instructions will get you a copy of the role for your ansible playbook. On
 
 ### Prerequisities
 
-Ansible 2.2.1.0 version installed.
+Ansible 2.4.1.0 version installed.
 Inventory destination should be a Debian environment.
 
 For testing purposes, [Molecule](https://molecule.readthedocs.io/) with [Vagrant](https://www.vagrantup.com/) as driver (with [landrush](https://github.com/vagrant-landrush/landrush) plugin) and [VirtualBox](https://www.virtualbox.org/) as provider.
@@ -74,7 +74,7 @@ See molecule.yml to check possible testing platforms.
 
 ## Built With
 
-![Ansible](https://img.shields.io/badge/ansible-2.2.1.0-green.svg)
+![Ansible](https://img.shields.io/badge/ansible-2.4.1.0-green.svg)
 
 ## Versioning
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   company: Idealista S.A.
   description: Apache Airflow role
-  min_ansible_version: 2.2.1.0
+  min_ansible_version: 2.4.1.0
   license: Apache 2.0
   platforms:
     - name: Debian

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -53,6 +53,7 @@
   pip:
     name: apache-airflow
     version: "{{ airflow_version }}"
+    extra_args: --no-cache-dir
   register: airflow_install
 
 - name: Airflow | Installing Airflow Extra Packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
 - name: Airflow | Install
-  include: install.yml
+  import_tasks: install.yml
   tags:
     - install
 
 - name: Airflow | Config
-  include: config.yml
+  import_tasks: config.yml
   tags:
     - config
 
 - name: Airflow | Service
-  include: service.yml
+  import_tasks: service.yml
   tags:
     - service


### PR DESCRIPTION
Changing 2 minor things:

- `extra_args: --no-cache-dir` allows us to run this playbook on GCE `f1-micro` instance
- `include` has been deprecated by ansible, using `import_tasks` instead