### PR TITLE
fix warnings with lists install and jinja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/airflow-role/tree/develop)
+### Fixed
+- *[#47](https://github.com/idealista/airflow-role/issues/50) Fix deprecation warning from jinja templates @adrimarteau
 
 ## [1.7.2](https://github.com/idealista/airflow-role/tree/1.7.2)
 [Full Changelog](https://github.com/idealista/airflow-role/compare/1.7.1...1.7.2)

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -26,10 +26,9 @@
 
 - name: Airflow | Installing dependencies
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ airflow_required_libs }}"
     state: present
     update_cache: yes
-  with_items: "{{ airflow_required_libs }}"
 
 - name: Airflow | Installing Python pip dependencies
   pip:
@@ -71,9 +70,8 @@
 - name: Airflow | Installing Airflow Extra Packages
   pip:
     executable: "{{ airflow_pip_executable }}"
-    name: apache-airflow[{{ item }}]
+    name: apache-airflow[{{ airflow_extra_packages }}]
     version: "{{ airflow_version }}"
-  with_items: "{{ airflow_extra_packages }}"
   when: airflow_extra_packages
 
 - name: Airflow | Installing DAGs dependencies
@@ -104,4 +102,4 @@
     mode: 0644
   notify: restart {{ item.key }}
   with_dict: "{{ airflow_services }}"
-  when: "{{ item.value.enabled }}"
+  when: item.value.enabled

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -7,5 +7,5 @@
     enabled: "{{ item.value.enabled }}"
     daemon_reload: yes
   with_dict: "{{ airflow_services }}"
-  when: "{{ item.value.enabled }}"
+  when: item.value.enabled
   changed_when: false


### PR DESCRIPTION
### Description of the Change
The main change is to install the airflow extra package from a concatenated list like:
```
airflow_extra_packages: celery,postgres
```
without raising the warning:
```
[DEPRECATION WARNING]: Invoking "pip" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "apache-airflow[{{ item }}]"`, please use `name: '{{
airflow_extra_packages }}'` and remove the loop. This feature will be removed in version 2.11. 
```

I have also modified a few task to clear other warnings:
 * in `Airflow | Installing dependencies`:
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `pkg: "{{ item }}"`, please use `pkg: '{{ airflow_required_libs }}'` and remove the loop. This feature will be removed in version 2.11
```
 * in `Airflow | Copy Daemon scripts` and `Airflow | Configuring service`:
```
[WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ item.value.enabled }}
```

### Benefits
The role will be compatible with `ansible==2.11`

### Applicable Issues
fix #50 