### PR TITLE
defaults/main.yml: Use {{ airflow_home }} in the default airflow_data…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/airflow-role/tree/develop)
 
+## [1.7.3](https://github.com/idealista/airflow-role/tree/1.7.3)
+[Full Changelog](https://github.com/idealista/airflow-role/compare/1.7.2...1.7.3)
+### Fixed
+- *[#55](https://github.com/idealista/airflow-role/pull/55) Use `{{ airflow_home }}` to set the default `airflow_database_conn` in defaults/main.yml* @davestern
+
 ## [1.7.2](https://github.com/idealista/airflow-role/tree/1.7.2)
 [Full Changelog](https://github.com/idealista/airflow-role/compare/1.7.1...1.7.2)
 ### Fixed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,7 +104,7 @@ airflow_encrypt_s3_logs: False
 airflow_s3_log_folder: # DEPRECATED
 
 ## DB
-airflow_database_conn: sqlite:////etc/airflow/airflow.db
+airflow_database_conn: sqlite:///{{ airflow_home }}/airflow.db
 airflow_database_pool_size: 5
 airflow_database_pool_recycle: 2000
 


### PR DESCRIPTION

**Description of the Change**

Using `{{ airflow_home }}` to properly set the default `airflow_database_conn` defaults/main.yml if it's changed by the user.

Additionally, remove one of the slashes after `sqlite:///` which causes connections to fail on ubuntu 18.04

**Benefits**

Users who set a different `airflow_home` will not see errors with the default DB install into a directory that does not exist (`/etc/airflow`)

**Possible Drawbacks**

It's possible the change to `sqlite:///` may cause problems on another OS, but from the documentation I saw, this does not appear to be the case.

**Applicable Issues**

None
