### PR TITLE
v1.7.3 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/airflow-role/tree/develop)
+
+## [1.7.2](https://github.com/idealista/airflow-role/tree/1.7.2)
+[Full Changelog](https://github.com/idealista/airflow-role/compare/1.7.1...1.7.2)
 ### Fixed
 - *[#47](https://github.com/idealista/airflow-role/issues/47) Fix web UI when using LDAP and Airflow>=1.10* @jnogol
 


### PR DESCRIPTION
### Fixed
- *[#55](https://github.com/idealista/airflow-role/pull/55) Use `{{ airflow_home }}` to set the default `airflow_database_conn` in defaults/main.yml* @davestern