### PR TITLE
Bugfix/wrong task handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/airflow-role/tree/develop)
-<!-- [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.0...bugfix/broken-features-release-2.0.0) -->
+
+[Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.1...bugfix/wrong-task-handler)
+
+- :hammer_and_wrench: Fix notify handler typo in task ➡️ [#99](https://github.com/idealista/airflow-role/issues/99) [BUG] notify restart airflow services not found when installing DAG dependencies
 
 ## [2.0.1](https://github.com/idealista/airflow-role/tree/2.0.1)
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -145,10 +145,10 @@
   with_items: "{{ dags_dependencies }}"
   when: dags_dependencies is defined
   notify:
-    - restart airflow_webserver
-    - restart airflow_scheduler
-    - restart airflow_worker
-    - restart airflow_flower
+    - restart airflow-webserver
+    - restart airflow-scheduler
+    - restart airflow-worker
+    - restart airflow-flower
 
 - name: Airflow | Copy Environment File
   template:


### PR DESCRIPTION
### Description of the Change

Typo fix, changed a "_" with a "-" in the notify handler of the DAG dependencies task to notify to the correct handler

### Benefits

Now the services are going to be restarted as normal

### Possible Drawbacks

Not known

### Applicable Issues
#99 [BUG] notify restart airflow services not found when installing DAG dependencies
