### PR TITLE
Fix notify handler typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/airflow-role/tree/develop)
+<!-- [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.0...bugfix/broken-features-release-2.0.0) -->
 
-[Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.0...bugfix/broken-features-release-2.0.0)
+## [2.0.1](https://github.com/idealista/airflow-role/tree/2.0.1)
+
+[Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.0...2.0.1)
 
 ### Changed
 
@@ -14,8 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ### Fixed
 
-- :hammer_and_wrench: Fix environment template PATH
-- :hammer_and_wrench: Fix wrong typed and escaped log options in airflow-cfg.yaml group_vars
+- :hammer_and_wrench: Fix environment template PATH ➡️ [#96](https://github.com/idealista/airflow-role/issues/96) [BUG] Servie PATH environment not working as expected
+- :hammer_and_wrench: Fix wrong typed and escaped log options in airflow-cfg.yaml group_vars ➡️ [#95](https://github.com/idealista/airflow-role/issues/95) [BUG] Tasks Log view is broken
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/airflow-role/tree/develop)
 
-[Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.1...bugfix/wrong-task-handler)
+<!-- [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.1...bugfix/wrong-task-handler) -->
+
+## [2.0.2](https://github.com/idealista/airflow-role/tree/2.0.2)
+
+[Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.1...2.0.2)
+
+### Fixed
 
 - :hammer_and_wrench: Fix notify handler typo in task ➡️ [#99](https://github.com/idealista/airflow-role/issues/99) [BUG] notify restart airflow services not found when installing DAG dependencies
 
 ## [2.0.1](https://github.com/idealista/airflow-role/tree/2.0.1)
-
-[Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.0...2.0.1)
 
 ### Changed
 


### PR DESCRIPTION
### Description of the Change

Typo fix, changed a "_" with a "-" in the notify handler of the DAG dependencies task to notify to the correct handler

### Benefits

Now the services are going to be restarted as normal

### Possible Drawbacks

Not known

### Applicable Issues
Closes #99 [BUG] notify restart airflow services not found when installing DAG dependencies
