### PR TITLE
Fix gunicorn logrotate kill command path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 <!-- [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.1...bugfix/wrong-task-handler) -->
 
+- fix wrong webserver.pid path in template gunicorn-logrotate.j2
+
 ## [2.0.3](https://github.com/idealista/airflow-role/tree/2.0.3)
 
 [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.2...2.0.3)
@@ -41,7 +43,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Changed
 
 - :arrows_clockwise: Update missing vars in cfg (v2) template
-- :arrows_clockwise: Update conditionally vars missing or unnecesary in cfg (v2) template
+- :arrows_clockwise: Update conditionally vars missing or unnecessary in cfg (v2) template
 
 ### Fixed
 
@@ -51,7 +53,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 
 - :heavy_plus_sign: tags for config files related
-- :broom: Clean airflow-cfg.yml with bad format values and unnecesary quotation
+- :broom: Clean airflow-cfg.yml with bad format values and unnecessary quotation
 
 ## [2.0.0](https://github.com/idealista/airflow-role/tree/2.0.0)
 

--- a/templates/gunicorn-logrotate.j2
+++ b/templates/gunicorn-logrotate.j2
@@ -8,6 +8,6 @@
     create 644 {{ airflow_user }} {{ airflow_group }}
     sharedscripts
     postrotate
-        [ -f {{ airflow_pidfile_folder }}-webserver/webserver.pid ] && kill -USR1 `cat {{ airflow_pidfile_folder }}/webserver.pid`
+        [ -f {{ airflow_pidfile_folder }}-webserver/webserver.pid ] && kill -USR1 `cat {{ airflow_pidfile_folder }}-webserver/webserver.pid`
     endscript
 }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

As pointed out [here](https://github.com/idealista/airflow-role/issues/110), i think the gunicorn logrotate path is not correct.

### Benefits

<!-- What benefits will be realized by the code change? -->

logrotate successfully works otherwise it wont find the path "/run/airflow/webserver.pid"

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None or any known

### Applicable Issues

<!-- Enter any applicable Issues here -->
#110 