### PR TITLE
Fix gunicorn logrotate kill command path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/airflow-role/tree/develop)
 
-[Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.1...bugfix/wrong-task-handler)
+<!-- [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.1...bugfix/wrong-task-handler) -->
+
+## [2.0.2](https://github.com/idealista/airflow-role/tree/2.0.2)
+
+[Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.1...2.0.2)
+
+### Fixed
 
 - :hammer_and_wrench: Fix notify handler typo in task ➡️ [#99](https://github.com/idealista/airflow-role/issues/99) [BUG] notify restart airflow services not found when installing DAG dependencies
 
 ## [2.0.1](https://github.com/idealista/airflow-role/tree/2.0.1)
-
-[Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.0...2.0.1)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 <!-- [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.1...bugfix/wrong-task-handler) -->
 
-- fix wrong webserver.pid path in template gunicorn-logrotate.j2
+## [2.0.4](https://github.com/idealista/airflow-role/tree/2.0.4)
+
+[Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.3...2.0.4)
+
+### Fixed
+- Wrong webserver.pid path in template gunicorn-logrotate.j2 [#110](https://github.com/idealista/airflow-role/issues/110) @ginolegigot
 
 ## [2.0.3](https://github.com/idealista/airflow-role/tree/2.0.3)
 


### PR DESCRIPTION
### Description of the Change

As pointed out [here](https://github.com/idealista/airflow-role/issues/110), i think the gunicorn logrotate path is not correct.

### Benefits

logrotate successfully works otherwise it wont find the path "/run/airflow/webserver.pid"

### Possible Drawbacks

None or any known

### Applicable Issues

Closes #110 