### PR TITLE
Fix broken build psycopg2

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,5 @@
+exclude_paths:
+  - ./molecule
+parseable: true
+use_default_rules: true
+verbosity: 1

--- a/.yamllint
+++ b/.yamllint
@@ -20,7 +20,7 @@ rules:
   commas:
     max-spaces-after: -1
     level: error
-  comments: disable
+  comments: enable
   comments-indentation: disable
   document-start: disable
   empty-lines:
@@ -31,8 +31,8 @@ rules:
   indentation: enable
   key-duplicates: enable
   line-length: disable
-  new-line-at-end-of-file: disable
+  new-line-at-end-of-file: enable
   new-lines:
     type: unix
-  trailing-spaces: disable
+  trailing-spaces: enable
   truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/airflow-role/tree/develop)
 
+## [2.0.5](https://github.com/idealista/airflow-role/tree/2.0.5)
+
+[Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.4...2.0.5)
+
 ### Fixed
 
 - :hammer_and_wrench: change psycopg2 to use the binary option to fix broken build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,25 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/airflow-role/tree/develop)
 
-<!-- [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.1...bugfix/wrong-task-handler) -->
+### Fixed
+
+- :hammer_and_wrench: change psycopg2 to use the binary option to fix broken build
+- :hammer_and_wrench: Fix typos
+
+### Added
+
+- :heavy_plus_sign: Add anisble-lint config file
+
+### Changed
+
+- :arrows_clockwise: Update Readme
 
 ## [2.0.4](https://github.com/idealista/airflow-role/tree/2.0.4)
 
 [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.3...2.0.4)
 
 ### Fixed
-- Wrong webserver.pid path in template gunicorn-logrotate.j2 [#110](https://github.com/idealista/airflow-role/issues/110) @ginolegigot
+- :hammer_and_wrench: Wrong webserver.pid path in template gunicorn-logrotate.j2 [#110](https://github.com/idealista/airflow-role/issues/110) @ginolegigot
 
 ## [2.0.3](https://github.com/idealista/airflow-role/tree/2.0.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 <!-- [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.1...bugfix/wrong-task-handler) -->
 
-- fix wrong webserver.pid path in template gunicorn-logrotate.j2
+## [2.0.4](https://github.com/idealista/airflow-role/tree/2.0.4)
+
+[Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.3...2.0.4)
+
+### Fixed
+- Wrong webserver.pid path in template gunicorn-logrotate.j2 [#110](https://github.com/idealista/airflow-role/issues/110) @ginolegigot
 
 ## [2.0.3](https://github.com/idealista/airflow-role/tree/2.0.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 <!-- [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.1...bugfix/wrong-task-handler) -->
 
+- fix wrong webserver.pid path in template gunicorn-logrotate.j2
+
 ## [2.0.3](https://github.com/idealista/airflow-role/tree/2.0.3)
 
 [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.2...2.0.3)
@@ -41,7 +43,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Changed
 
 - :arrows_clockwise: Update missing vars in cfg (v2) template
-- :arrows_clockwise: Update conditionally vars missing or unnecesary in cfg (v2) template
+- :arrows_clockwise: Update conditionally vars missing or unnecessary in cfg (v2) template
 
 ### Fixed
 
@@ -51,7 +53,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 
 - :heavy_plus_sign: tags for config files related
-- :broom: Clean airflow-cfg.yml with bad format values and unnecesary quotation
+- :broom: Clean airflow-cfg.yml with bad format values and unnecessary quotation
 
 ## [2.0.0](https://github.com/idealista/airflow-role/tree/2.0.0)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Apache Airflow Ansible role [![Build Status](https://travis-ci.org/idealista/airflow-role.png)](https://travis-ci.org/idealista/airflow-role)
+# Apache Airflow Ansible role
+
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/idealista/airflow-role?color=%23B62682) [![Ansible Galaxy](https://img.shields.io/badge/galaxy-idealista.clickhouse_role-B62682.svg)](https://galaxy.ansible.com/idealista/clickhouse_role) [![Build Status](https://travis-ci.org/idealista/airflow-role.png)](https://travis-ci.org/idealista/airflow-role)
 
 ![Logo](https://raw.githubusercontent.com/idealista/airflow-role/master/logo.gif)
 
@@ -111,9 +113,15 @@ airflow_extra_packages:
 
 ## Testing :test_tube:
 
-```shell
+```bash
 pipenv install -r test-requirements.txt --python 3.7
-pipenv run molecule test
+
+# Optional
+pipenv shell  # if in shell just use `molecule COMMAND`
+
+pipenv run molecule test  # To run role test
+# or
+pipenv run molecule converge  # To run play with the role
 ```
 
 ## Built With :building_construction:

--- a/defaults/main/airflow-cfg.yml
+++ b/defaults/main/airflow-cfg.yml
@@ -156,7 +156,7 @@ airflow_webserver_access_logformat:
 airflow_webserver_expose_config: False
 airflow_webserver_expose_hostname: True
 airflow_webserver_expose_stacktrace: True
-airflow_webserver_dag_default_view: tree # Valid values are: tree, graph, duration, gantt, landing_times
+airflow_webserver_dag_default_view: tree  # Valid values are: tree, graph, duration, gantt, landing_times
 airflow_webserver_dag_orientation: LR
 airflow_webserver_log_fetch_timeout_sec: 5
 airflow_webserver_log_fetch_delay_sec: 2

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -25,7 +25,7 @@ airflow_constraint_url: "https://raw.githubusercontent.com/apache/airflow/constr
 # https://airflow.apache.org/docs/apache-airflow/stable/extra-packages-ref.html
 # List should follow Ansible's YAML basics:
 # https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html#yaml-basics
-airflow_bundle_package: # all|all_dbs|devel|devel_hadoop|devel_all|devel_ci See bundle extras section 
+airflow_bundle_package:  # all|all_dbs|devel|devel_hadoop|devel_all|devel_ci See bundle extras section
 # airflow_extra_packages:
   # [Apache]
   # - apache.atlas

--- a/defaults/main/webserver-config-py.yml
+++ b/defaults/main/webserver-config-py.yml
@@ -23,12 +23,12 @@ airflow_AUTH_LDAP_LASTNAME_FIELD: sn
 airflow_AUTH_LDAP_EMAIL_FIELD: mail  # if null in LDAP, email is set to: "{username}@email.notfound"
 
 # search configs
-airflow_AUTH_LDAP_SEARCH: # the LDAP search base
-airflow_AUTH_LDAP_UID_FIELD: # the username field
-airflow_AUTH_LDAP_BIND_USER: # the special bind username for search
-airflow_AUTH_LDAP_BIND_PASSWORD: # the special bind password for search
+airflow_AUTH_LDAP_SEARCH:  # the LDAP search base
+airflow_AUTH_LDAP_UID_FIELD:  # the username field
+airflow_AUTH_LDAP_BIND_USER:  # the special bind username for search
+airflow_AUTH_LDAP_BIND_PASSWORD:  # the special bind password for search
 
-airflow_AUTH_LDAP_SEARCH_FILTER: # limit the LDAP search scope
+airflow_AUTH_LDAP_SEARCH_FILTER:  # limit the LDAP search scope
 
 # Setup Full admin role name
 airflow_AUTH_ROLE_ADMIN: Admin

--- a/molecule/default/group_vars/airflow_group/main.yml
+++ b/molecule/default/group_vars/airflow_group/main.yml
@@ -32,8 +32,8 @@ airflow_regular_users:
     email: eren@attack.com
 
 airflow_required_python_packages:
-  - { name: SQLAlchemy, version: 1.3.23 }
-  - { name: psycopg2 }
+  - { name: SQLAlchemy, version: 1.3.23 }  # see https://github.com/apache/airflow/blob/main/setup.cfg#L157-L161
+  - { name: psycopg2-binary }
 
 # [smtp]
 airflow_smtp_host: localhost

--- a/molecule/extra_packages/group_vars/airflow_group/main.yml
+++ b/molecule/extra_packages/group_vars/airflow_group/main.yml
@@ -14,7 +14,7 @@ airflow_admin_users:
 
 airflow_required_python_packages:
   - { name: SQLAlchemy, version: 1.3.23 }
-  - { name: psycopg2 }
+  - { name: psycopg2-binary }
 
 airflow_extra_packages:
   - celery

--- a/templates/gunicorn-logrotate.j2
+++ b/templates/gunicorn-logrotate.j2
@@ -8,6 +8,6 @@
     create 644 {{ airflow_user }} {{ airflow_group }}
     sharedscripts
     postrotate
-        [ -f {{ airflow_pidfile_folder }}-webserver/webserver.pid ] && kill -USR1 `cat {{ airflow_pidfile_folder }}/webserver.pid`
+        [ -f {{ airflow_pidfile_folder }}-webserver/webserver.pid ] && kill -USR1 `cat {{ airflow_pidfile_folder }}-webserver/webserver.pid`
     endscript
 }


### PR DESCRIPTION
### Description of the Change

- change psycopg2 to use the binary option to fix broken build
- Fix typos
- Add anisble-lint config file
- Update Readme

### Benefits

Fix build

### Possible Drawbacks

Not known

### Applicable Issues
Closing #113 
