### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/airflow-role/tree/develop)
 
+## [3.0.1](https://github.com/idealista/airflow-role/tree/3.0.1)
+
+[Full Changelog](https://github.com/idealista/airflow-role/compare/3.0.0...3.0.1)
+
+### Fixed
+
+- `base_log_folder` is fixed in default config due to wrong `log_folder` named var
+
 ## [3.0.0](https://github.com/idealista/airflow-role/tree/3.0.0)
 
 [Full Changelog](https://github.com/idealista/airflow-role/compare/2.0.7...3.0.0)

--- a/defaults/main/airflow-cfg.yml
+++ b/defaults/main/airflow-cfg.yml
@@ -14,7 +14,7 @@ airflow_cfg_default:
       plugins_folder: "{{ airflow_app_home }}/plugins"
   - section: logging
     settings:
-      logs_folder: "{{ airflow_logs_folder }}"
+      base_log_folder: "{{ airflow_logs_folder }}"
       dag_processor_manager_log_location: "{{ airflow_logs_folder }}/dag_processor_manager/dag_processor_manager.log"
   - section: webserver
     settings:


### PR DESCRIPTION
### Description of the Change

set `base_log_folder` instead of `base_log`


### Benefits

Logs path folder correctly configurable

### Possible Drawbacks

Not known

### Applicable Issues

close #128
